### PR TITLE
updated express-jwt dependency to get local server to working state a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/express-jwt": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.3.tgz",
-      "integrity": "sha512-UdB8p5O8vGYTKm3SfREnLgVGIGEHcL3lrVyi3ebEX2qhMuagN623ju7ywWis+qYL+CXE7G1qPc2bCPBAg2MxZQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
+      "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
       "dependencies": {
         "async": "^1.5.0",
         "express-unless": "^0.3.0",
@@ -5568,9 +5568,9 @@
       }
     },
     "express-jwt": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.3.tgz",
-      "integrity": "sha512-UdB8p5O8vGYTKm3SfREnLgVGIGEHcL3lrVyi3ebEX2qhMuagN623ju7ywWis+qYL+CXE7G1qPc2bCPBAg2MxZQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
+      "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
       "requires": {
         "async": "^1.5.0",
         "express-unless": "^0.3.0",

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const PORT = process.env.PORT || 7000
 const path = require("path")
 require("dotenv").config()
 
+
 app.use(express.json())
 app.use(morgan("dev"))
 
@@ -27,6 +28,8 @@ app.use("/api/perform", require("./routes/performRouter"))
 app.use("/api/about", require("./routes/aboutRouter"))
 app.use("/api/text", require("./routes/textRouter"))
 app.use(express.static(path.join(__dirname, "client", "build")))
+
+
 
 
 


### PR DESCRIPTION
I initially upgraded express-jwt to the latest version in attempt to clear the error "app.use("/api", expressJwt({ secret: process.env.SECRET }))
                ^TypeError: expressJwt is not a function"

That didn't work, so I reverted back to the older version that was already installed and then I restarted the server.  This fixed the issue.  The correct version of express-jwt needed to run the server is  "express-jwt": "^5.3.1", which is the older version.  I was able to get the site to run locally and tested the form out yet again, which was successful.  I have no idea why it didn't work initially, but it's working now.  

